### PR TITLE
Fix USER required when it should be USERNAME ID:1615

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -5,5 +5,5 @@ Figaro.application = Figaro::Application.new(environment: 'production',
 Figaro.load
 Figaro.require_keys('PSRP_PORT',
                     'RELATIVITY_HOST',
-                    'USER',
+                    'USERNAME',
                     'PASSWORD')


### PR DESCRIPTION
https://westernmilling.tpondemand.com/entity/1615

My nightly restart cron is failing due to this. This fixes it.